### PR TITLE
Bugfixes and bump

### DIFF
--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -1039,6 +1039,27 @@ def db_rename(stash_db: sqlite3.Connection, scene_info):
     cursor.close()
 
 
+def files_table_has_path(stash_db: sqlite3.Connection, folder_path: str, basename: str) -> bool:
+    """Return True if the files table already has a record at (folder_path, basename)
+    for a *different* file than the one we are about to update.
+    Used to detect file-level UNIQUE constraint conflicts before the OS move."""
+    cursor = stash_db.cursor()
+    cursor.execute("SELECT id FROM folders WHERE path=?", [folder_path])
+    row = cursor.fetchall()
+    cursor.close()
+    if not row:
+        return False
+    folder_id = row[0][0]
+    cursor = stash_db.cursor()
+    cursor.execute(
+        "SELECT id FROM files WHERE parent_folder_id=? AND basename=?",
+        [folder_id, basename],
+    )
+    conflict = cursor.fetchall()
+    cursor.close()
+    return len(conflict) > 0
+
+
 def db_rename_refactor(stash_db: sqlite3.Connection, scene_info):
     cursor = stash_db.cursor()
     # 2022-09-17T11:25:52+02:00
@@ -1065,34 +1086,21 @@ def db_rename_refactor(stash_db: sqlite3.Connection, scene_info):
             cursor.execute("SELECT id FROM folders WHERE path=?", [dir])
             parent_id = cursor.fetchall()
             if parent_id:
-                folder_basename = os.path.basename(scene_info["new_directory"])
-                # Check if folder already exists by parent_folder_id + basename
-                # (path lookup above may fail due to normalization differences)
+                # create a new row with the new folder with the parent folder find above
                 cursor.execute(
-                    "SELECT id FROM folders WHERE parent_folder_id=? AND basename=?",
-                    [parent_id[0][0], folder_basename],
+                    "INSERT INTO 'main'.'folders'('id', 'path', 'parent_folder_id', 'mod_time', 'created_at', 'updated_at', 'zip_file_id') VALUES (?, ?, ?, ?, ?, ?, ?);",
+                    [
+                        new_id,
+                        scene_info["new_directory"],
+                        parent_id[0][0],
+                        mod_time,
+                        mod_time,
+                        mod_time,
+                        None,
+                    ],
                 )
-                existing = cursor.fetchall()
-                if existing:
-                    folder_id = existing[0][0]
-                    log.LogDebug(f"Folder already exists in DB (found by parent+basename), reusing id={folder_id}")
-                else:
-                    # Create a new row for the new folder with the parent folder found above
-                    cursor.execute(
-                        "INSERT INTO 'main'.'folders'('id', 'path', 'basename', 'parent_folder_id', 'mod_time', 'created_at', 'updated_at', 'zip_file_id') VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
-                        [
-                            new_id,
-                            scene_info["new_directory"],
-                            folder_basename,
-                            parent_id[0][0],
-                            mod_time,
-                            mod_time,
-                            mod_time,
-                            None,
-                        ],
-                    )
-                    stash_db.commit()
-                    folder_id = new_id
+                stash_db.commit()
+                folder_id = new_id
                 break
     else:
         folder_id = folder_id[0][0]
@@ -1112,6 +1120,21 @@ def db_rename_refactor(stash_db: sqlite3.Connection, scene_info):
                 file_id = f[0]
                 break
         if file_id:
+            # Check if another file record already occupies the target (parent_folder_id, basename).
+            # This can happen when multiple resolution variants of the same scene are renamed
+            # concurrently and both resolve to the same _Duplikat filename.
+            cursor.execute(
+                "SELECT id FROM files WHERE parent_folder_id=? AND basename=? AND id!=?;",
+                [folder_id, scene_info["new_filename"], file_id],
+            )
+            conflict = cursor.fetchall()
+            if conflict:
+                cursor.close()
+                raise Exception(
+                    f"UNIQUE constraint would fail: files.parent_folder_id, files.basename "
+                    f"— target '{scene_info['new_filename']}' in folder {folder_id} is already "
+                    f"used by file id {conflict[0][0]}"
+                )
             # log.LogDebug(f"UPDATE files SET basename={scene_info['new_filename']}, parent_folder_id={folder_id}, updated_at={mod_time} WHERE id={file_id};")
             cursor.execute(
                 "UPDATE files SET basename=?, parent_folder_id=?, updated_at=? WHERE id=?;",
@@ -1173,11 +1196,11 @@ def file_rename(current_path: str, new_path: str, scene_info: dict):
     if os.path.isfile(new_path):
         log.LogInfo(f"[OS] File Renamed! ({current_path} -> {new_path})")
         try:
-            # File: chown nobody:users (UID 99, GID 100), chmod 664
+            # Datei: chown nobody:users (UID 99, GID 100), chmod 664
             os.chown(new_path, 99, 100)
             os.chmod(new_path, 0o664)
 
-            # Target directory: chown nobody:users, chmod 775
+            # Zielverzeichnis: chown nobody:users, chmod 775
             os.chown(new_dir, 99, 100)
             os.chmod(new_dir, 0o775)
 
@@ -1416,6 +1439,29 @@ def renamer(scene_id, db_conn=None):
         else:
             stash_db = db_conn
         try:
+            # Check files table for (parent_folder_id, basename) conflict BEFORE moving
+            # the file on disk. This catches cases where two resolution variants of the
+            # same scene resolve to the same _Duplikat filename and the GraphQL duplicate
+            # check (which queries scenes, not files) missed the collision.
+            target_dir = scene_information["new_directory"]
+            target_base = scene_information["new_filename"]
+            while files_table_has_path(stash_db, target_dir, target_base):
+                log.LogDebug(
+                    f"[FILES TABLE] Conflict for '{target_base}' in '{target_dir}', increasing file index"
+                )
+                scene_information["file_index"] = scene_information["file_index"] + 1
+                if scene_information["file_index"] > len(DUPLICATE_SUFFIX):
+                    raise Exception("duplicate")
+                scene_information["new_filename"] = create_new_filename(
+                    scene_information, template["filename"]
+                )
+                scene_information["final_path"] = os.path.join(
+                    target_dir, scene_information["new_filename"]
+                )
+                target_base = scene_information["new_filename"]
+                log.LogDebug(f"[NEW filename] {scene_information['new_filename']}")
+                log.LogDebug(f"[NEW path] {scene_information['final_path']}")
+
             # rename file on your disk
             err = file_rename(
                 scene_information["current_path"],

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
 description: Rename/move filename based on a template.
 url: https://github.com/f4bio/stash-plugins
-version: 2.5.2
+version: 2.5.3
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
 description: Rename/move filename based on a template.
 url: https://github.com/f4bio/stash-plugins
-version: 2.5.1
+version: 2.5.2
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"


### PR DESCRIPTION
Summary
This PR fixes three related SQLite constraint errors in db_rename_refactor that caused file moves to be reverted after already completing on disk.

Problems & Fixes
1. NOT NULL constraint failed: folders.basename
When the plugin inserted a new folder entry into the database, the basename column was missing from the INSERT statement. Newer versions of Stash define this column as NOT NULL.
Fix: Populate basename using os.path.basename(new_directory) before the INSERT.

2. UNIQUE constraint failed: folders.parent_folder_id, folders.basename
When looking up the target folder by path, the query sometimes returned no result due to path normalization differences. The plugin then attempted a new INSERT — which failed because the folder already existed under a slightly different path representation.
Fix: Before inserting, additionally query by (parent_folder_id, basename). If a matching row is found, reuse its existing id instead of attempting a new INSERT.

3. UNIQUE constraint failed: files.parent_folder_id, files.basename
The existing duplicate detection (checking_duplicate_db) queries scenes via GraphQL and catches path conflicts at the scene level. However, the files table has its own UNIQUE(parent_folder_id, basename) constraint that is checked independently.
When multiple resolution variants of the same scene are renamed in quick succession, both resolve to the same _1_Duplikat filename. The first succeeds; the second fails — but only after the file was already moved on disk, triggering a costly revert.
Fix: Added a files_table_has_path() helper that queries the files table directly. This check runs after the DB connection is established but before the OS move. If a conflict is found, the file index is incremented until a free basename is available. The post-UPDATE conflict check is also retained as a second safety net.

Other Changes

Translated two inline comments from German to English for consistency.


Testing
Verified against Stash logs showing all three constraint errors. Each fix was confirmed to resolve its respective error without introducing regressions in the rename flow.