### PR TITLE
feat: skip rename when required template fields are missing (closes #11)

### DIFF
--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -1286,6 +1286,30 @@ def associated_rename(scene_info: dict):
                         )
 
 
+def get_missing_required_fields(template_str: str, scene_info: dict) -> list:
+    """
+    Return a list of required field names that are missing (null/empty) in scene_info.
+
+    Fields inside optional {} groups are excluded from this check — they are
+    designed to be silently dropped when empty. Only fields outside {} are
+    considered required.
+
+    Example: "{[$studio] }{$date - }$title"
+        - $studio and $date are optional (inside {})
+        - $title is required (outside {})
+    """
+    # Strip optional groups so only required field references remain
+    required_part = re.sub(r"\{[^{}]*\}", "", template_str)
+    required_fields = re.findall(r"\$(\w+)", required_part)
+    missing = []
+    for field in required_fields:
+        # Normalise: strip trailing underscore variants (e.g. performer_path)
+        key = field.strip("_")
+        if not scene_info.get(key):
+            missing.append(f"${field}")
+    return missing
+
+
 def _matches_pattern(value: str, pattern_config: dict) -> bool:
     """Check if a value matches a pattern config dict with type (exact|regex) and pattern."""
     import re as _re
@@ -1427,6 +1451,20 @@ def renamer(scene_id, db_conn=None):
 
         scene_information["scene_id"] = scene_id
         scene_information["file_index"] = i
+
+        # Check that all required (non-optional) template fields are present
+        if REQUIRE_FIELDS:
+            missing = []
+            if template.get("filename"):
+                missing += get_missing_required_fields(template["filename"], scene_information)
+            if template.get("path") and template["path"].get("destination"):
+                missing += get_missing_required_fields(template["path"]["destination"], scene_information)
+            if missing:
+                log.LogWarning(
+                    f"[{scene_id}] Skipping rename: required field(s) {missing} are empty. "
+                    f"Set require_fields = False in config to rename anyway."
+                )
+                continue
 
         for removed_field in ORDER_SHORTFIELD:
             if removed_field:
@@ -1691,6 +1729,9 @@ EXCLUDE_ENABLED = getattr(config, "exclude_enabled", False)
 EXCLUDE_TAG_PATTERNS = getattr(config, "exclude_tag_patterns", {})
 EXCLUDE_STUDIO_PATTERNS = getattr(config, "exclude_studio_patterns", {})
 EXCLUDE_PATH_PATTERNS = getattr(config, "exclude_path_patterns", {})
+
+# Require all template fields setting
+REQUIRE_FIELDS = getattr(config, "require_fields", True)
 
 DB_VERSION = graphql_getBuild()
 if DB_VERSION >= DB_VERSION_FILE_REFACTOR:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
 description: Rename/move filename based on a template.
 url: https://github.com/f4bio/stash-plugins
-version: 2.6.0
+version: 2.6.1
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"

--- a/plugins/renamerOnUpdate/renamerOnUpdate_config.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate_config.py
@@ -277,6 +277,30 @@ use_ascii = False
 # =========================
 
 ######################################
+#         Field Requirements         #
+# ---------------------------------- #
+# Skip the rename if a required      #
+# template field is null or empty.   #
+#                                    #
+# Fields inside {} optional groups   #
+# are NOT checked — they are already #
+# designed to be dropped when empty. #
+# Only fields outside {} count.      #
+#                                    #
+# Example template:                  #
+#   {[$studio] }{$date - }$title     #
+#   -> $studio and $date are optional#
+#   -> $title is REQUIRED            #
+#                                    #
+# Set to False to always rename,     #
+# even with incomplete metadata.     #
+######################################
+
+# Skip rename when required fields are missing (recommended: True).
+# Prevents filenames like "[1080p]_1.mp4" for unscraped scenes.
+require_fields = True
+
+######################################
 #         Exclude Settings           #
 # ---------------------------------- #
 # Prevent specific scenes from being #

--- a/plugins/renamerOnUpdate/tests/test_renamer.py
+++ b/plugins/renamerOnUpdate/tests/test_renamer.py
@@ -235,3 +235,81 @@ class TestDateParsing:
 
     def test_empty_string_returns_none(self):
         assert _parse_date("") is None
+
+
+# ---------------------------------------------------------------------------
+# get_missing_required_fields
+# ---------------------------------------------------------------------------
+
+def get_missing_required_fields(template_str: str, scene_info: dict) -> list:
+    """Replicated from renamerOnUpdate.py for isolated testing."""
+    import re
+    required_part = re.sub(r"\{[^{}]*\}", "", template_str)
+    required_fields = re.findall(r"\$(\w+)", required_part)
+    missing = []
+    for field in required_fields:
+        key = field.strip("_")
+        if not scene_info.get(key):
+            missing.append(f"${field}")
+    return missing
+
+
+class TestGetMissingRequiredFields:
+
+    def _info(self, **kwargs):
+        base = {"title": None, "date": None, "studio": None, "height": None, "performer": None}
+        base.update(kwargs)
+        return base
+
+    def test_all_required_present(self):
+        info = self._info(title="My Scene", date="2024-01-01", height="1080p")
+        assert get_missing_required_fields("$title - $date [$height]", info) == []
+
+    def test_title_missing(self):
+        info = self._info(date="2024-01-01", height="1080p")
+        missing = get_missing_required_fields("$title - $date [$height]", info)
+        assert "$title" in missing
+
+    def test_date_missing(self):
+        info = self._info(title="My Scene", height="1080p")
+        missing = get_missing_required_fields("$title - $date [$height]", info)
+        assert "$date" in missing
+
+    def test_optional_fields_not_checked(self):
+        # $studio and $date are optional (inside {}), only $title is required
+        info = self._info(title="My Scene")  # no studio, no date
+        template = "{[$studio] }{$date - }$title"
+        missing = get_missing_required_fields(template, info)
+        assert missing == []
+
+    def test_optional_field_missing_ignored(self):
+        info = self._info(title="My Scene")
+        template = "{$studio - }$title"
+        assert get_missing_required_fields(template, info) == []
+
+    def test_multiple_missing(self):
+        info = self._info()  # all None
+        missing = get_missing_required_fields("$title - $date [$height]", info)
+        assert "$title" in missing
+        assert "$date" in missing
+        assert "$height" in missing
+
+    def test_empty_template(self):
+        info = self._info(title="My Scene")
+        assert get_missing_required_fields("", info) == []
+
+    def test_all_optional(self):
+        # entire template is optional
+        info = self._info()
+        template = "{[$studio] }{$date - }{$title}"
+        assert get_missing_required_fields(template, info) == []
+
+    def test_path_template(self):
+        info = {"studio": "BangBros", "year": "2024"}
+        template = "/data/zugeord/$studio/$year"
+        assert get_missing_required_fields(template, info) == []
+
+    def test_path_template_missing_studio(self):
+        info = {"studio": None, "year": "2024"}
+        template = "/data/zugeord/$studio/$year"
+        assert "$studio" in get_missing_required_fields(template, info)


### PR DESCRIPTION
Fixes the case where unscraped scenes with no title/date/studio get renamed to garbage filenames like '[1080p]_1.mp4'.

Changes:
- Add get_missing_required_fields(template, scene_info) helper Fields inside {} optional groups are excluded from the check. Only fields outside {} (truly required) are validated. Example: '{[$studio] }{$date - }$title' -> only $title is required.
- Add REQUIRE_FIELDS constant (default True via getattr fallback)
- In renamer() main loop: if REQUIRE_FIELDS and any required field is missing, log a warning and skip the file (continue to next)
- Add require_fields = True to renamerOnUpdate_config.py with a detailed comment explaining the optional vs required distinction
- Bump version: 2.6.0 -> 2.6.1

Testing:
- 10 new unit tests for get_missing_required_fields
- 40 passed in 0.13s